### PR TITLE
fix: (revert) business api call to getJobData error

### DIFF
--- a/nodes/Visualping/GenericFunctions.ts
+++ b/nodes/Visualping/GenericFunctions.ts
@@ -124,7 +124,8 @@ export async function getJobData(this: IHookFunctions, jobId: number) {
 	const options: IHttpRequestOptions = {
 		method: 'GET',
 		url: `${apiRoutes.job}/${jobId}`,
-		body: {
+		qs: {
+			jobId,
 			...(organisation?.id && { organisationId: organisation.id }),
 		},
 		json: true,


### PR DESCRIPTION
Reverts webmonitoring/n8n-nodes-visualping#16